### PR TITLE
Fix Feature Permission Check

### DIFF
--- a/src/main/java/de/lachcrafter/lachshield/features/Feature.java
+++ b/src/main/java/de/lachcrafter/lachshield/features/Feature.java
@@ -40,7 +40,7 @@ public abstract class Feature implements Listener {
      * @return if the player has the permission
      */
     public boolean hasFeaturePermission(Player player) {
-        return player.hasPermission(getPermission()) && player.hasPermission("lachshield.admin");
+        return player.hasPermission(getPermission()) || player.hasPermission("lachshield.admin");
     }
 
     public abstract void onEnable();


### PR DESCRIPTION
The current `hasFeaturePermission` method checks if the player has both the feature permission and the admin permission. It should be an or so they only need one of those permissions instead.